### PR TITLE
Run compatibility tests in the real browsers (closes #2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "eslint": "^1.3.1",
     "jscs": "^2.1.1",
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "wd": "^0.3.12"
   }
 }

--- a/test/atob.js
+++ b/test/atob.js
@@ -2,65 +2,17 @@
 
 const assert = require('assert');
 const atob = require('..').atob;
-const stripChars = require('./util').stripChars;
-
-const cases = ['', 'abcd', ' abcd', 'abcd ', ' abcd===', 'abcd=== ',
-    'abcd ===', 'a', 'ab', 'abc', 'abcde', String.fromCharCode(0xd800, 0xdc00),
-    '=', '==', '===', '====', '=====',
-    'a=', 'a==', 'a===', 'a====', 'a=====',
-    'ab=', 'ab==', 'ab===', 'ab====', 'ab=====',
-    'abc=', 'abc==', 'abc===', 'abc====', 'abc=====',
-    'abcd=', 'abcd==', 'abcd===', 'abcd====', 'abcd=====',
-    'abcde=', 'abcde==', 'abcde===', 'abcde====', 'abcde=====',
-    '=a', '=a=', 'a=b', 'a=b=', 'ab=c', 'ab=c=', 'abc=d', 'abc=d=',
-    // With whitespace
-    'ab\tcd', 'ab\ncd', 'ab\fcd', 'ab\rcd', 'ab cd', 'ab\u00a0cd',
-    'ab\t\n\f\r cd', ' \t\n\f\r ab\t\n\f\r cd\t\n\f\r ',
-    'ab\t\n\f\r =\t\n\f\r =\t\n\f\r ',
-    // Test if any bits are set at the end.  These should all be fine, since
-    // they end with A, which becomes 0:
-    'A', '/A', '//A', '///A', '////A',
-    // These are all bad, since they end in / (= 63, all bits set) but their
-    // length isn't a multiple of four characters, so they can't be output by
-    // btoa().  Thus one might expect some UAs to throw exceptions or otherwise
-    // object, since they could never be output by btoa(), so they're good to
-    // test.
-    '/', 'A/', 'AA/', 'AAAA/',
-    // But this one is possible:
-    'AAA/',
-    // Binary-safety tests
-    '\0nonsense', 'abcd\0nonsense',
-    // WebIDL tests
-    undefined, null, 7, 12, 1.5, true, false, NaN, +Infinity, -Infinity, 0, -0,
-    {toString: function () { return 'foo'; }},
-    {toString: function () { return 'abcd'; }}
-];
-
-// TODO: make this less terrible
-const answers = [
-  [],[105,183,29],[105,183,29],[105,183,29],null,null,null,null,[105],
-  [105,183],null,null,null,null,null,null,null,null,null,null,null,null,
-  null,[105],null,null,null,[105,183],null,null,null,null,null,null,null,
-  null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,
-  [105,183,29],[105,183,29],[105,183,29],[105,183,29],[105,183,29],null,
-  [105,183,29],[105,183,29],[105],null,[252],[255,240],[255,255,192],null,
-  null,[3],[0,15],null,[0,0,63],null,null,null,[158,233,101],null,[215],null,
-  [182,187,158],null,[53,163],[34,119,226,158,43,114],null,null,null,[126,138],
-  [105,183,29]
-];
+const util = require('./util');
+const data = require('./fixtures/atob');
+const cases = data.cases;
+const answers = data.answers;
 
 describe('atob', function () {
 
   cases.forEach(function (input, index) {
-    let expected = answers[index];
-
-    // TODO: update answers so this is unnecessary
-    if (expected instanceof Array) {
-      expected = String.fromCharCode.apply(null, expected);
-    }
-
-    const inputDescriptor = stripChars(input);
-    const expectedDescriptor = stripChars(expected);
+    const expected = util.getAnswer(answers, index);
+    const inputDescriptor = util.stripChars(input);
+    const expectedDescriptor = util.stripChars(expected);
 
     it(`correctly converts ${inputDescriptor} into ${expectedDescriptor}`, function () {
       assert.strictEqual(atob(input), expected);

--- a/test/browser.js
+++ b/test/browser.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const assert = require('assert');
+const wd = require('wd');
+const util = require('./util');
+const abab = require('..');
+const atob = abab.atob;
+const btoa = abab.btoa;
+
+function escape(input) {
+    return typeof input === 'string' ? JSON.stringify(input) : '' +input;
+}
+
+function evaluateExpression(fn, input) {
+    return `(function() {
+      try {
+        return ${fn}(${escape(input)});
+      } catch(e) {
+        return null;
+      }
+    })()`
+}
+
+const browsers = ['chrome', 'firefox', 'internet explorer'];
+
+if (process.env.SAUCE_USERNAME) {
+  const SAUCE_USERNAME = process.env.SAUCE_USERNAME;
+  const SAUCE_ACCESS_KEY = process.env.SAUCE_ACCESS_KEY;
+
+  describe('browser compatibility', function () {
+    browsers.forEach(function (browserName) {
+      describe(browserName, function () {
+        var browser;
+        before(function () {
+          this.timeout(10000);
+          return browser = wd.promiseChainRemote('ondemand.saucelabs.com', 80, SAUCE_USERNAME, SAUCE_ACCESS_KEY)
+            .init({browserName: browserName})
+            .get('about:blank');
+        });
+        after(function () {
+          return browser.quit();
+        });
+
+        beforeEach(function() {
+            this.timeout(10000);
+        });
+
+        describe('atob', function () {
+          const data = require('./fixtures/atob');
+          const cases = data.cases;
+          const answers = data.answers;
+          cases.forEach(function (input, index) {
+            const expected = util.getAnswer(answers, index);
+            const inputDescriptor = util.stripChars(input);
+            const expectedDescriptor = util.stripChars(expected);
+
+            it(`correctly converts ${inputDescriptor} into ${expectedDescriptor}`, function () {
+              return browser.eval(evaluateExpression('atob', input)).then(function (result) {
+                assert.strictEqual(atob(input), result);
+              });
+            });
+          });
+        });
+
+        describe('btoa', function () {
+          const data = require('./fixtures/btoa');
+          const cases = data.cases;
+          const answers = data.answers;
+          cases.forEach(function (input, index) {
+            const expected = util.getAnswer(answers, index);
+            const inputDescriptor = util.stripChars(input);
+            const expectedDescriptor = util.stripChars(expected);
+
+            it(`correctly converts ${inputDescriptor} into ${expectedDescriptor}`, function () {
+              return browser.eval(evaluateExpression('btoa', input)).then(function (result) {
+                assert.strictEqual(btoa(input), result);
+              });
+            });
+          });
+        });
+
+      });
+    });
+  });
+} else {
+  xit('browser tests are skipped', function () {});
+}

--- a/test/btoa.js
+++ b/test/btoa.js
@@ -2,40 +2,17 @@
 
 const assert = require('assert');
 const btoa = require('..').btoa;
-const stripChars = require('./util').stripChars;
-
-const cases = ['עברית', '', 'ab', 'abc', 'abcd', 'abcde',
-  // This one is thrown in because IE9 seems to fail atob(btoa()) on it.  Or
-  // possibly to fail btoa().  I actually can't tell what's happening here,
-  // but it doesn't hurt.
-  '\xff\xff\xc0',
-  // Is your DOM implementation binary-safe?
-  '\0a', 'a\0b',
-  // WebIDL tests.
-  undefined, null, 7, 12, 1.5, true, false, NaN, +Infinity, -Infinity, 0, -0,
-  {toString: function () { return 'foo'; }}
-];
-
-// TODO: make this less terrible
-const answers = [null,[],[89,87,73,61],[89,87,74,106],[89,87,74,106,90,65,61,61],
-[89,87,74,106,90,71,85,61],[47,47,47,65],[65,71,69,61],[89,81,66,105],
-[100,87,53,107,90,87,90,112,98,109,86,107],[98,110,86,115,98,65,61,61],[78,119,61,61],
-[77,84,73,61],[77,83,52,49],[100,72,74,49,90,81,61,61],[90,109,70,115,99,50,85,61],
-[84,109,70,79],[83,87,53,109,97,87,53,112,100,72,107,61],
-[76,85,108,117,90,109,108,117,97,88,82,53],[77,65,61,61],[77,65,61,61],[90,109,57,118]];
+const util = require('./util');
+const data = require('./fixtures/btoa');
+const cases = data.cases;
+const answers = data.answers;
 
 describe('btoa', function () {
 
   cases.forEach(function (input, index) {
-    let expected = answers[index];
-
-    // TODO: update answers so this is unnecessary
-    if (expected instanceof Array) {
-      expected = String.fromCharCode.apply(null, expected);
-    }
-
-    const inputDescriptor = stripChars(input);
-    const expectedDescriptor = stripChars(expected);
+    const expected = util.getAnswer(answers, index);
+    const inputDescriptor = util.stripChars(input);
+    const expectedDescriptor = util.stripChars(expected);
 
     it(`correctly converts ${inputDescriptor} into ${expectedDescriptor}`, function () {
       assert.strictEqual(btoa(input), expected);

--- a/test/fixtures/atob.js
+++ b/test/fixtures/atob.js
@@ -1,0 +1,44 @@
+module.exports.cases = ['', 'abcd', ' abcd', 'abcd ', ' abcd===', 'abcd=== ',
+    'abcd ===', 'a', 'ab', 'abc', 'abcde', String.fromCharCode(0xd800, 0xdc00),
+    '=', '==', '===', '====', '=====',
+    'a=', 'a==', 'a===', 'a====', 'a=====',
+    'ab=', 'ab==', 'ab===', 'ab====', 'ab=====',
+    'abc=', 'abc==', 'abc===', 'abc====', 'abc=====',
+    'abcd=', 'abcd==', 'abcd===', 'abcd====', 'abcd=====',
+    'abcde=', 'abcde==', 'abcde===', 'abcde====', 'abcde=====',
+    '=a', '=a=', 'a=b', 'a=b=', 'ab=c', 'ab=c=', 'abc=d', 'abc=d=',
+    // With whitespace
+    'ab\tcd', 'ab\ncd', 'ab\fcd', 'ab\rcd', 'ab cd', 'ab\u00a0cd',
+    'ab\t\n\f\r cd', ' \t\n\f\r ab\t\n\f\r cd\t\n\f\r ',
+    'ab\t\n\f\r =\t\n\f\r =\t\n\f\r ',
+    // Test if any bits are set at the end.  These should all be fine, since
+    // they end with A, which becomes 0:
+    'A', '/A', '//A', '///A', '////A',
+    // These are all bad, since they end in / (= 63, all bits set) but their
+    // length isn't a multiple of four characters, so they can't be output by
+    // btoa().  Thus one might expect some UAs to throw exceptions or otherwise
+    // object, since they could never be output by btoa(), so they're good to
+    // test.
+    '/', 'A/', 'AA/', 'AAAA/',
+    // But this one is possible:
+    'AAA/',
+    // Binary-safety tests
+    '\0nonsense', 'abcd\0nonsense',
+    // WebIDL tests
+    undefined, null, 7, 12, 1.5, true, false, NaN, +Infinity, -Infinity, 0, -0,
+    {toString: function () { return 'foo'; }},
+    {toString: function () { return 'abcd'; }}
+];
+
+// TODO: make this less terrible
+module.exports.answers = [
+  [],[105,183,29],[105,183,29],[105,183,29],null,null,null,null,[105],
+  [105,183],null,null,null,null,null,null,null,null,null,null,null,null,
+  null,[105],null,null,null,[105,183],null,null,null,null,null,null,null,
+  null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,
+  [105,183,29],[105,183,29],[105,183,29],[105,183,29],[105,183,29],null,
+  [105,183,29],[105,183,29],[105],null,[252],[255,240],[255,255,192],null,
+  null,[3],[0,15],null,[0,0,63],null,null,null,[158,233,101],null,[215],null,
+  [182,187,158],null,[53,163],[34,119,226,158,43,114],null,null,null,[126,138],
+  [105,183,29]
+];

--- a/test/fixtures/btoa.js
+++ b/test/fixtures/btoa.js
@@ -1,0 +1,19 @@
+module.exports.cases = ['עברית', '', 'ab', 'abc', 'abcd', 'abcde',
+  // This one is thrown in because IE9 seems to fail atob(btoa()) on it.  Or
+  // possibly to fail btoa().  I actually can't tell what's happening here,
+  // but it doesn't hurt.
+  '\xff\xff\xc0',
+  // Is your DOM implementation binary-safe?
+  '\0a', 'a\0b',
+  // WebIDL tests.
+  undefined, null, 7, 12, 1.5, true, false, NaN, +Infinity, -Infinity, 0, -0,
+  {toString: function () { return 'foo'; }}
+];
+
+// TODO: make this less terrible
+module.exports.answers = [null,[],[89,87,73,61],[89,87,74,106],[89,87,74,106,90,65,61,61],
+[89,87,74,106,90,71,85,61],[47,47,47,65],[65,71,69,61],[89,81,66,105],
+[100,87,53,107,90,87,90,112,98,109,86,107],[98,110,86,115,98,65,61,61],[78,119,61,61],
+[77,84,73,61],[77,83,52,49],[100,72,74,49,90,81,61,61],[90,109,70,115,99,50,85,61],
+[84,109,70,79],[83,87,53,109,97,87,53,112,100,72,107,61],
+[76,85,108,117,90,109,108,117,97,88,82,53],[77,65,61,61],[77,65,61,61],[90,109,57,118]];

--- a/test/util.js
+++ b/test/util.js
@@ -1,3 +1,4 @@
+'use strict';
 module.exports = {
   stripChars: function (str) {
     if (typeof str === 'string') {
@@ -5,5 +6,14 @@ module.exports = {
     } else {
       return str;
     }
+  },
+  getAnswer: function (answers, index) {
+    const expected = answers[index];
+
+    // TODO: update answers so this is unnecessary
+    if (expected instanceof Array) {
+      return String.fromCharCode.apply(null, expected);
+    }
+    return expected;
   }
 };


### PR DESCRIPTION
Added test suite, which runs the same test fixtures in real browsers and compares results.

Karma is not necessary to do it. It can be done using `eval` method in the WebDriver API, which executes a script in remote browser.

To run tests in SauceLabs you need a key. Provide key and username to tests via environment variables:
```
SAUCE_USER=<user> SAUCE_KEY=<key> npm test
```