### PR TITLE
Add IE to Sauce along with IE exempt cases for atob

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 env:
   node: true
   mocha: true
+  browser: true
 extends: eslint:recommended
 ecmaFeatures:
   blockBindings: true

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,5 @@
 function prefixTag(tagValue, tagPrefix) {
-  return tagValue ? (tagPrefix ? tagPrefix + ":" + tagValue : tagValue) : undefined;
+  return tagValue ? (tagPrefix ? tagPrefix + ':' + tagValue : tagValue) : undefined;
 }
 
 const sauceBrowsers = {
@@ -17,13 +17,14 @@ const sauceBrowsers = {
   }
 };
 const browsers = process.env.SAUCE_USERNAME ? Object.keys(sauceBrowsers) : ['Firefox'];
-if(!!process.env.SAUCE_USERNAME !== !!process.env.SAUCE_ACCESS_KEY) {
-    throw new Error('Both SAUCE_USERNAME and SAUCE_ACCESS_KEY should be configured');
+
+if (!!process.env.SAUCE_USERNAME !== !!process.env.SAUCE_ACCESS_KEY) {
+  throw new Error('Both SAUCE_USERNAME and SAUCE_ACCESS_KEY should be configured');
 }
 
-module.exports = function(config) {
+module.exports = function (config) {
   config.set({
-    basePath: "",
+    basePath: '',
     files: ['./test/browser/*.js'],
 
     preprocessors: {
@@ -40,24 +41,24 @@ module.exports = function(config) {
       }
     },
 
-    frameworks: ["mocha"],
+    frameworks: ['mocha'],
 
-    reporters: ["dots", "saucelabs"],
+    reporters: ['dots', 'saucelabs'],
 
     sauceLabs: {
       title: process.env.BUILD_NAME,
       tags:
         [
-          prefixTag(process.env.TRAVIS_BRANCH, "branch"),
-          prefixTag(process.env.TRAVIS_PULL_REQUEST, "pr"),
-          prefixTag(process.env.TRAVIS_COMMIT, "commit"),
-          prefixTag(process.env.TRAVIS_TAG, "tag")
+          prefixTag(process.env.TRAVIS_BRANCH, 'branch'),
+          prefixTag(process.env.TRAVIS_PULL_REQUEST, 'pr'),
+          prefixTag(process.env.TRAVIS_COMMIT, 'commit'),
+          prefixTag(process.env.TRAVIS_TAG, 'tag')
         ]
-        .filter(function(t) {
+        .filter(function (t) {
           // Remove useless tags
-          return !!t && t !== "false";
+          return !!t && t !== 'false';
         }),
-      "public": "public"
+      'public': 'public'
 
     },
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,11 +5,15 @@ function prefixTag(tagValue, tagPrefix) {
 const sauceBrowsers = {
   'Chrome': {
     base: 'SauceLabs',
-    browserName: 'chrome'
+    browserName: 'Chrome'
   },
   'Firefox': {
     base: 'SauceLabs',
-    browserName: 'firefox'
+    browserName: 'Firefox'
+  },
+  'Internet Explorer': {
+    base: 'SauceLabs',
+    browserName: 'Internet Explorer'
   }
 };
 const browsers = process.env.SAUCE_USERNAME ? Object.keys(sauceBrowsers) : ['Firefox'];

--- a/test/browser/atob.js
+++ b/test/browser/atob.js
@@ -5,11 +5,12 @@ const assert = require('assert');
 const atob = require('../..').atob;
 const stripChars = require('../util').stripChars;
 const cases = require('../fixtures/atob').cases;
+const ieExemptCases = require('../fixtures/ie-exempt').cases;
 
 function browserAtob(input) {
   try {
     return window.atob(input);
-  } catch(e) {
+  } catch (e) {
     return null;
   }
 }

--- a/test/browser/atob.js
+++ b/test/browser/atob.js
@@ -19,6 +19,10 @@ describe('atob', function () {
   cases.forEach(function (input) {
     const inputDescriptor = stripChars(input);
 
+    if (navigator.userAgent.indexOf('Windows') >= 0 && ieExemptCases.indexOf(input) >= 0) {
+      return;
+    }
+
     it(`correctly converts ${inputDescriptor}`, function () {
       assert.strictEqual(atob(input), browserAtob(input));
     });

--- a/test/browser/btoa.js
+++ b/test/browser/btoa.js
@@ -9,7 +9,7 @@ const cases = require('../fixtures/atob').cases;
 function browserBtoa(input) {
   try {
     return window.btoa(input);
-  } catch(e) {
+  } catch (e) {
     return null;
   }
 }

--- a/test/fixtures/ie-exempt.js
+++ b/test/fixtures/ie-exempt.js
@@ -1,0 +1,13 @@
+module.exports.cases = [
+  ' abcd',
+  'abcd ',
+  'ab\tcd',
+  'ab\ncd',
+  'ab\fcd',
+  'ab\rcd',
+  'ab cd',
+  'ab\u00a0cd',
+  'ab\t\n\f\r cd',
+  ' \t\n\f\r ab\t\n\f\r cd\t\n\f\r ',
+  'ab\t\n\f\r =\t\n\f\r =\t\n\f\r '
+];

--- a/test/node/atob.js
+++ b/test/node/atob.js
@@ -7,7 +7,6 @@ const data = require('../fixtures/atob');
 const cases = data.cases;
 const answers = data.answers;
 
-
 describe('atob', function () {
 
   cases.forEach(function (input, index) {

--- a/test/node/btoa.js
+++ b/test/node/btoa.js
@@ -7,7 +7,6 @@ const data = require('../fixtures/btoa');
 const cases = data.cases;
 const answers = data.answers;
 
-
 describe('btoa', function () {
 
   cases.forEach(function (input, index) {


### PR DESCRIPTION
This allows us to run tests in IE on Sauce while skipping 11 problem cases (all involve IE's `atob` throwing errors on whitespace).

@just-boris would appreciate your thoughts on this!

The diff is kind of muddled up by lint fixes - here's a better view of what happened: 8076d7f18f2a6ee5b0ea2e30d6783f006a53f38d

Closes #9
