### PR TITLE
Update LICENSE to specify contributions from this repo

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-License reproduced from [w3c/web-platform-tests](https://github.com/w3c/web-platform-tests/blob/master/LICENSE.md#w3c-3-clause-bsd-license).
+Both the original source code and new contributions in this repository are released under the [W3C 3-clause BSD license](https://github.com/w3c/web-platform-tests/blob/master/LICENSE.md#w3c-3-clause-bsd-license).
 
 # W3C 3-clause BSD License
 


### PR DESCRIPTION
Pointed out in #19, the contributions specific to this repo are not mentioned in LICENSE.md. This adds a clause to call them out explicitly and release the new contributions under the same license as the original code.

cc/@0x326