### PR TITLE
Version 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+- Added license file
+
 ## 1.0.3
 
 - Replaced `let` with `var` in `lib/btoa.js`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abab",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "WHATWG spec-compliant implementations of window.atob and window.btoa.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
This is just a version bump (and changelog update).
The only change - adding a license file - was already committed months ago, but a new version which includes it was never released, hence this PR.