### PR TITLE
Set the correct license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "browser"
   ],
   "author": "Jeff Carpenter <gcarpenterv@gmail.com>",
-  "license": "BSD New",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/jsdom/abab/issues"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "browser"
   ],
   "author": "Jeff Carpenter <gcarpenterv@gmail.com>",
-  "license": "SEE LICENSE IN LICENSE.md",
+  "license": "BSD New",
   "bugs": {
     "url": "https://github.com/jsdom/abab/issues"
   },


### PR DESCRIPTION
The license in LICENSE.md is the BSD 3-Clause license, identified as "BSD New" according to the full license text (https://tldrlegal.com/license/bsd-3-clause-license-(revised)#fulltext).

Specifying the correct license in the package.json makes it easier to review dependencies for license compatibility.