### PR TITLE
Using a lookup string in the atobLookup and btoaLookup functions

### DIFF
--- a/lib/atob.js
+++ b/lib/atob.js
@@ -84,12 +84,14 @@ function atob(data) {
  * A lookup table for atob(), which converts an ASCII character to the
  * corresponding six-bit number.
  */
+
+const keystr =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+
 function atobLookup(chr) {
-  const keystr =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-  const idx = keystr.indexOf(chr);
-  // Throw exception; should not be hit in tests
-  return idx < 0 ? undefined : idx;
+  const index = keystr.indexOf(chr);
+  // Throw exception if character is not in the lookup string; should not be hit in tests
+  return index < 0 ? undefined : index;
 }
 
 module.exports = atob;

--- a/lib/atob.js
+++ b/lib/atob.js
@@ -86,7 +86,7 @@ function atob(data) {
  */
 
 const keystr =
-  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 function atobLookup(chr) {
   const index = keystr.indexOf(chr);

--- a/lib/atob.js
+++ b/lib/atob.js
@@ -85,23 +85,11 @@ function atob(data) {
  * corresponding six-bit number.
  */
 function atobLookup(chr) {
-  if (/[A-Z]/.test(chr)) {
-    return chr.charCodeAt(0) - "A".charCodeAt(0);
-  }
-  if (/[a-z]/.test(chr)) {
-    return chr.charCodeAt(0) - "a".charCodeAt(0) + 26;
-  }
-  if (/[0-9]/.test(chr)) {
-    return chr.charCodeAt(0) - "0".charCodeAt(0) + 52;
-  }
-  if (chr === "+") {
-    return 62;
-  }
-  if (chr === "/") {
-    return 63;
-  }
+  const keystr =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+  const idx = keystr.indexOf(chr);
   // Throw exception; should not be hit in tests
-  return undefined;
+  return idx < 0 ? undefined : idx;
 }
 
 module.exports = atob;

--- a/lib/btoa.js
+++ b/lib/btoa.js
@@ -43,12 +43,12 @@ function btoa(s) {
  * Lookup table for btoa(), which converts a six-bit number into the
  * corresponding ASCII character.
  */
-function btoaLookup(idx) {
-  const keystr =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+const keystr =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
 
-  if (idx >= 0 && idx < 64) {
-    return keystr[idx];
+function btoaLookup(index) {
+  if (index >= 0 && index < 64) {
+    return keystr[index];
   }
 
   // Throw INVALID_CHARACTER_ERR exception here -- won't be hit in the tests.

--- a/lib/btoa.js
+++ b/lib/btoa.js
@@ -44,21 +44,13 @@ function btoa(s) {
  * corresponding ASCII character.
  */
 function btoaLookup(idx) {
-  if (idx < 26) {
-    return String.fromCharCode(idx + "A".charCodeAt(0));
+  const keystr =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+
+  if (idx >= 0 && idx < 64) {
+    return keystr[idx];
   }
-  if (idx < 52) {
-    return String.fromCharCode(idx - 26 + "a".charCodeAt(0));
-  }
-  if (idx < 62) {
-    return String.fromCharCode(idx - 52 + "0".charCodeAt(0));
-  }
-  if (idx === 62) {
-    return "+";
-  }
-  if (idx === 63) {
-    return "/";
-  }
+
   // Throw INVALID_CHARACTER_ERR exception here -- won't be hit in the tests.
   return undefined;
 }

--- a/lib/btoa.js
+++ b/lib/btoa.js
@@ -44,7 +44,7 @@ function btoa(s) {
  * corresponding ASCII character.
  */
 const keystr =
-  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 function btoaLookup(index) {
   if (index >= 0 && index < 64) {

--- a/test/node.js
+++ b/test/node.js
@@ -6,6 +6,29 @@ const assert = require("assert");
 const abab = require("..");
 const fixtures = require("./fixtures");
 
+const keystr =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+
+for (let i = 0; i < 256; i++) {
+  const input = `\0\0${String.fromCharCode(i)}`;
+  const output = abab.btoa(input);
+
+  const expectedOutput = `AA${keystr[Math.floor(i / 64)]}${keystr[i % 64]}`;
+
+  it(`correctly converts ASCII char ${i} into ${expectedOutput}`, () => {
+    assert.strictEqual(expectedOutput, output);
+  });
+}
+
+for (let i = 0; i < 64; i++) {
+  const input = `AAA${keystr[i]}`;
+  const output = abab.atob(input);
+
+  it(`correctly converts ${input} into ${keystr[i]}`, () => {
+    assert.strictEqual(i, output.charCodeAt(2));
+  });
+}
+
 ["atob", "btoa"].forEach(abFnKey => {
   const abFn = abab[abFnKey];
   const cases = fixtures.get(abFnKey);

--- a/test/node.js
+++ b/test/node.js
@@ -7,7 +7,7 @@ const abab = require("..");
 const fixtures = require("./fixtures");
 
 const keystr =
-  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 for (let i = 0; i < 256; i++) {
   const input = `\0\0${String.fromCharCode(i)}`;


### PR DESCRIPTION
I stumbled upon [this implementation](http://www.webtoolkit.info/javascript_base64.html) of a base64 encoder and decoder after successfully having used abab. 

They do something smart that I replicated in this PR, which is using a lookup string for the supported characters instead of the sequence of `if`s and obscure `String.charCodeAt()`-offsets that were previously found on the atobLookup and btoaLookup functions.

I think this is way more readable, and at the same time it could be somehow faster in the case of atoaLookup because we skip 3 regex tests on each single character of the string.

I respected the choice to return undefined by both functions when the characters were outside the considered range, tests are all running green.

Cheers!