### PR TITLE
Throw TypeError when passed zero arguments

### DIFF
--- a/lib/atob.js
+++ b/lib/atob.js
@@ -5,6 +5,10 @@
  * instead of throwing INVALID_CHARACTER_ERR we return null.
  */
 function atob(data) {
+  if (arguments.length === 0) {
+    throw new TypeError("1 argument required, but only 0 present.");
+  }
+
   // Web IDL requires DOMStrings to just be converted using ECMAScript
   // ToString, which in our case amounts to using a template literal.
   data = `${data}`;

--- a/lib/btoa.js
+++ b/lib/btoa.js
@@ -5,6 +5,10 @@
  * RFC 4648.
  */
 function btoa(s) {
+  if (arguments.length === 0) {
+    throw new TypeError("1 argument required, but only 0 present.");
+  }
+
   let i;
   // String conversion as required by Web IDL.
   s = `${s}`;

--- a/test/browser.js
+++ b/test/browser.js
@@ -30,13 +30,15 @@ const browserAbab = {
   const browserFn = browserAbab[abFnKey];
   const cases = fixtures.get(abFnKey);
 
-  cases.forEach(testCase => {
-    if (navigator.userAgent.indexOf("Windows") >= 0 && ieExemptCases.indexOf(testCase.input) >= 0) {
-      return;
-    }
+  describe(abFnKey, () => {
+    cases.forEach(testCase => {
+      if (navigator.userAgent.indexOf("Windows") >= 0 && ieExemptCases.indexOf(testCase.input) >= 0) {
+        return;
+      }
 
-    it(`correctly converts ${testCase.inputDescriptor} into ${testCase.expectedDescriptor}`, () => {
-      assert.strictEqual(abFn(testCase.input), browserFn(testCase.input));
+      it(`correctly converts ${testCase.inputDescriptor} into ${testCase.expectedDescriptor}`, () => {
+        assert.strictEqual(abFn(testCase.input), browserFn(testCase.input));
+      });
     });
   });
 });

--- a/test/node.js
+++ b/test/node.js
@@ -33,15 +33,24 @@ for (let i = 0; i < 64; i++) {
   const abFn = abab[abFnKey];
   const cases = fixtures.get(abFnKey);
 
-  it(`${abFnKey} rejects symbol input`, () => {
-    assert.throws(() => {
-      abFn(Symbol.iterator);
-    }, TypeError);
-  });
+  describe(abFnKey, () => {
+    it(`rejects symbol input`, () => {
+      assert.throws(() => {
+        abFn(Symbol.iterator);
+      }, TypeError);
+    });
 
-  cases.forEach(testCase => {
-    it(`correctly converts ${testCase.inputDescriptor} into ${testCase.expectedDescriptor}`, () => {
-      assert.strictEqual(abFn(testCase.input), testCase.expected);
+    it("throws TypeError when passed no inputs", () => {
+      assert.throws(() => {
+        abFn();
+      }, TypeError);
+    });
+
+    cases.forEach(testCase => {
+      it(`correctly converts ${testCase.inputDescriptor} into ${testCase.expectedDescriptor}`, () => {
+        assert.strictEqual(abFn(testCase.input), testCase.expected);
+      });
     });
   });
 });
+


### PR DESCRIPTION
Fixes #68.

- Also add extra `describe` blocks around unit tests for readability.